### PR TITLE
Proper two throttle pot support

### DIFF
--- a/CanBrake.cpp
+++ b/CanBrake.cpp
@@ -147,7 +147,7 @@ uint16_t CanBrake::calculatePedalPosition(RawSignalData* rawSignal) {
 	if (config->maximumLevel1 == 0) //brake processing disabled if max is 0
 		return 0;
 
-	return normalizeInput(rawSignal->input1, config->minimumLevel1, config->maximumLevel1);
+	return normalizeAndConstrainInput(rawSignal->input1, config->minimumLevel1, config->maximumLevel1);
 }
 
 /*

--- a/CanThrottle.cpp
+++ b/CanThrottle.cpp
@@ -144,7 +144,7 @@ bool CanThrottle::validateSignal(RawSignalData* rawSignal) {
 uint16_t CanThrottle::calculatePedalPosition(RawSignalData* rawSignal) {
 	CanThrottleConfiguration *config = (CanThrottleConfiguration *) getConfiguration();
 
-	return normalizeInput(rawSignal->input1, config->minimumLevel1, config->maximumLevel1);
+	return normalizeAndConstrainInput(rawSignal->input1, config->minimumLevel1, config->maximumLevel1);
 }
 
 DeviceId CanThrottle::getId() {

--- a/Throttle.cpp
+++ b/Throttle.cpp
@@ -121,8 +121,15 @@ int16_t Throttle::mapPedalPosition(int16_t pedalPosition) {
  * Make sure input level stays within margins (min/max) then map the constrained
  * level linearly to a value from 0 to 1000.
  */
-uint16_t Throttle::normalizeInput(int32_t input, int32_t min, int32_t max) {
-	return map(constrain(input, min, max), min, max, (int32_t) 0, (int32_t) 1000);
+uint16_t Throttle::normalizeAndConstrainInput(int32_t input, int32_t min, int32_t max) {
+	return constrain(normalizeInput(input, min, max), (int32_t) 0, (int32_t) 1000);
+}
+
+/*
+ * Map the constrained level linearly to a signed value from 0 to 1000.
+ */
+int32_t Throttle::normalizeInput(int32_t input, int32_t min, int32_t max) {
+	return map(input, min, max, (int32_t) 0, (int32_t) 1000);
 }
 
 /*

--- a/Throttle.h
+++ b/Throttle.h
@@ -90,7 +90,8 @@ protected:
 	virtual bool validateSignal(RawSignalData *);
 	virtual uint16_t calculatePedalPosition(RawSignalData *);
 	virtual int16_t mapPedalPosition(int16_t);
-	uint16_t normalizeInput(int32_t, int32_t, int32_t);
+	uint16_t normalizeAndConstrainInput(int32_t, int32_t, int32_t);
+	int32_t normalizeInput(int32_t, int32_t, int32_t);
 
 private:
 	int16_t level; // the final signed throttle level. [-1000, 1000] in permille of maximum

--- a/ThrottleDetector.cpp
+++ b/ThrottleDetector.cpp
@@ -37,7 +37,7 @@ ThrottleDetector::ThrottleDetector(Throttle *throttle) {
 	this->throttle = throttle;
 	config = (PotThrottleConfiguration *) throttle->getConfiguration();
 	state = DoNothing;
-	maxThrottleReadingDeviationPercent = 50; // 5% in 0-1000 scale
+	maxThrottleReadingDeviationPercent = 100; // 10% in 0-1000 scale
 	Logger::debug("ThrottleDetector constructed with throttle %d", throttle);
 	resetValues();
 }
@@ -102,10 +102,6 @@ void ThrottleDetector::detect() {
  */
 void ThrottleDetector::detectMinWait() {
 	if ((millis() - startTime) >= 2000) {
-		// drop initial readings as they seem to be invalid
-		readThrottleValues();
-		resetValues();
-
 		// take MIN readings for 2 seconds
 		startTime = millis();
 		readThrottleValues();
@@ -123,9 +119,10 @@ void ThrottleDetector::detectMinCalibrate() {
 		displayCalibratedValues(true);
 
 		// save rest minimums
-		throttle1MinRest = throttle1Min;  // minimum sensor value at rest
-		throttle2MinRest = throttle2Min;  // minimum sensor value at rest
-		throttle2MaxRest = throttle2Max;  // maximum sensor value at rest
+		throttle1MinRest = throttle1Min;
+		throttle1MaxRest = throttle1Max;
+		throttle2MinRest = throttle2Min;
+		throttle2MaxRest = throttle2Max;
 
 		Logger::console("\nSmoothly depress the pedal to full acceleration");
 		Logger::console("and hold the pedal until complete");
@@ -141,11 +138,9 @@ void ThrottleDetector::detectMinCalibrate() {
  */
 void ThrottleDetector::detectMaxWait() {
 	if ((millis() - startTime) >= 5000 || sampleCount >= maxSamples * 2 / 3) {
-		// drop initial readings as they seem to be invalid
-		readThrottleValues();
-		resetValues();
 
 		// take MAX readings for 2 seconds
+		resetValues();
 		startTime = millis();
 		readThrottleValues();
 		state = DetectMaxCalibrate;
@@ -163,12 +158,18 @@ void ThrottleDetector::detectMaxCalibrate() {
 	} else {
 		displayCalibratedValues(false);
 
+		// take some stats before normalizing min/max
+		int throttle1MinFluctuation = abs(throttle1MaxRest-throttle1MinRest);
+		int throttle2MinFluctuation = abs(throttle2MaxRest-throttle2MinRest);
+		int throttle1MaxFluctuation = abs(throttle1Max-throttle1Min);
+		int throttle2MaxFluctuation = abs(throttle2Max-throttle2Min);
+
 		// Determine throttle type based off min/max
-		if (throttle1MinRest > throttle1Min) { // high to low pot
+		if (throttle1MinRest > throttle1Min+maxThrottleReadingDeviationPercent) { // high to low pot
 			throttle1HighLow = true;
 		}
 
-		if (throttle2MinRest > throttle2Min) { // high to low pot
+		if (throttle2MinRest > throttle2Min+maxThrottleReadingDeviationPercent) { // high to low pot
 			throttle2HighLow = true;
 		}
 
@@ -180,39 +181,48 @@ void ThrottleDetector::detectMaxCalibrate() {
 		}
 
 		// Detect grounded pin (always zero) or floating values which indicate no potentiometer provided
-		// If the values deviate by more than 15% we assume floating
-		int restDiff = abs(throttle2MaxRest-throttle2MinRest) * 100 / throttle2MaxRest;
-		int maxDiff = abs(throttle2Max-throttle2Min) * 100 / throttle2Max;
 		if ((throttle2MinRest == 0 && throttle2MaxRest == 0 && throttle2Min == INT16_MAX && throttle2Max == 0)
-				|| (restDiff > maxThrottleReadingDeviationPercent && maxDiff > maxThrottleReadingDeviationPercent)) {
+				|| (abs(throttle2MaxRest-throttle2Max) < maxThrottleReadingDeviationPercent
+						&& abs(throttle2MinRest-throttle2Min) < maxThrottleReadingDeviationPercent)) {
 			potentiometerCount = 1;
 		} else {
 			potentiometerCount = 2;
 		}
 
-		// restore the true min
-		throttle2Min = throttle2MinRest;
+		// restore the true min/max for T2
+		if ( throttle2Inverse ) {
+			throttle2Max = throttle2MaxRest;
+		} else {
+			throttle2Min = throttle2MinRest;
+		}
+
+		Logger::debug("Inverse: %s, throttle2Min: %d, throttle2Max: %d", (throttle2Inverse?"true":"false"), throttle2Min, throttle2Max);
+
+		// fluctuation percentages
+		throttle1MinFluctuationPercent = throttle1MinFluctuation*100/abs(throttle1Max-throttle1Min);
+		throttle1MaxFluctuationPercent = throttle1MaxFluctuation*100/abs(throttle1Max-throttle1Min);
+		throttle2MinFluctuationPercent = throttle2MinFluctuation*100/abs(throttle2Max-throttle2Min);
+		throttle2MaxFluctuationPercent = throttle2MaxFluctuation*100/abs(throttle2Max-throttle2Min);
 
 		// Determine throttle subtype by examining the data sampled
 		for (int i = 0; i < sampleCount; i++) {
 			// normalize the values to a 0-1000 scale using the found min/max
 			uint16_t value1 = normalize(throttle1Values[i], throttle1Min, throttle1Max, 0, 1000);
-			uint16_t value2 = normalize(throttle2Values[i], throttle2Inverse ? throttle2Max : throttle2Min,
-					throttle2Inverse ? throttle2Min : throttle2Max, 0, 1000);
+			uint16_t value2 = normalize(throttle2Values[i], throttle2Min, throttle2Max, 0, 1000);
 
 			// see if they match known subtypes
 			linearCount += checkLinear(value1, value2);
 			inverseCount += checkInverse(value1, value2);
 
-			//Logger::debug("NT1: %d, NT2: %d, L: %d, I: %d", value1, value2, linearCount, inverseCount);
+			//Logger::debug("T1: %d, T2: %d = NT1: %d, NT2: %d, L: %d, I: %d", throttle1Values[i], throttle2Values[i], value1, value2, linearCount, inverseCount);
 		}
 
 		throttleSubType = 0;
 		if (potentiometerCount > 1) {
 			// For dual pots, we trust the detection of >75%
-			if (linearCount / sampleCount * 100 > 75) {
+			if ((linearCount * 100) / sampleCount > 75) {
 				throttleSubType = 1;
-			} else if (inverseCount / sampleCount * 100 > 75) {
+			} else if ((inverseCount * 100) / sampleCount > 75) {
 				throttleSubType = 2;
 			}
 		} else {
@@ -222,6 +232,13 @@ void ThrottleDetector::detectMaxCalibrate() {
 			} else {
 				throttleSubType = 1;
 			}
+		}
+
+		char *type = "UNKNOWN";
+		if (throttleSubType == 1) {
+			type = "Linear";
+		} else if (throttleSubType == 2) {
+			type = "Inverse";
 		}
 
 		if ( Logger::isDebug()) {
@@ -235,31 +252,28 @@ void ThrottleDetector::detectMaxCalibrate() {
 		Logger::console("Detection complete");
 		Logger::console("Num samples taken: %d", sampleCount);
 		Logger::console("Num potentiometers found: %d", potentiometerCount);
-		Logger::console("T1: %d to %d %s", throttle1Min, throttle1Max, (throttle1HighLow ? "HIGH-LOW" : "LOW-HIGH"));
+		Logger::console("T1: %d to %d %s", (throttle1HighLow ? throttle1Max : throttle1Min), (throttle1HighLow ? throttle1Min : throttle1Max),
+				(throttle1HighLow ? "HIGH-LOW" : "LOW-HIGH"));
+		Logger::console("T1: rest fluctuation %d%%, full throttle fluctuation %d%%", throttle1MinFluctuationPercent, throttle1MaxFluctuationPercent);
 
 		if (potentiometerCount > 1) {
-			Logger::console("T2: %d to %d %s %s", (throttle2Inverse ? throttle2Max : throttle2Min), (throttle2Inverse ? throttle2Min : throttle2Max),
+			Logger::console("T2: %d to %d %s %s", (throttle2HighLow ? throttle2Max : throttle2Min), (throttle2HighLow ? throttle2Min : throttle2Max),
 					(throttle2HighLow ? "HIGH-LOW" : "LOW-HIGH"), (throttle2Inverse ? " (Inverse of T1)" : ""));
+			Logger::console("T2: rest fluctuation %d%%, full throttle fluctuation %d%%", throttle2MinFluctuationPercent, throttle2MaxFluctuationPercent);
 			Logger::console("Num linear throttle matches: %d", linearCount);
 			Logger::console("Num inverse throttle matches: %d", inverseCount);
 		}
 
-		char *type = "UNKNOWN";
-		if (throttleSubType == 1) {
-			type = "Linear";
-		} else if (throttleSubType == 2) {
-			type = "Inverse";
-		}
 		Logger::console("Throttle type: %s", type);
 		Logger::console("========================================");
 
 		// update the throttle's configuration (without storing it yet)
-		config->minimumLevel1 = (throttle1HighLow ? throttle1Max : throttle1Min);
-		config->maximumLevel1 = (throttle1HighLow ? throttle1Min : throttle1Max);
+		config->minimumLevel1 = throttle1Min;
+		config->maximumLevel1 = throttle1Max;
 		config->numberPotMeters = potentiometerCount;
 		if (config->numberPotMeters > 1) {
-			config->minimumLevel2 = (throttle2HighLow ? throttle2Max : throttle2Min);
-			config->maximumLevel2 = (throttle2HighLow ? throttle2Min : throttle2Max);
+			config->minimumLevel2 = throttle2Min;
+			config->maximumLevel2 = throttle2Max;
 		} else {
 			config->minimumLevel2 = 0;
 			config->maximumLevel2 = 0;
@@ -346,7 +360,7 @@ int ThrottleDetector::checkInverse(uint16_t throttle1Value, uint16_t throttle2Va
 
 void ThrottleDetector::displayCalibratedValues(bool minPedal) {
 	Logger::console("\nAt %s T1: %d to %d", (minPedal ? "MIN" : "MAX"), throttle1Min, throttle1Max);
-	if (potentiometerCount > 1)
+	//if (potentiometerCount > 1)
 		Logger::console(" T2: %d to %d", throttle2Min, throttle2Max);
 	Logger::console("");
 }

--- a/ThrottleDetector.h
+++ b/ThrottleDetector.h
@@ -79,8 +79,13 @@ private:
 	bool throttle2HighLow; // true if throttle2 ranges from highest to lowest value as the pedal is pressed
 	bool throttle2Inverse; // true if throttle2 values are the opposite of the throttle1 values.
 	int throttle1MinRest;  // minimum sensor value at rest
+	int throttle1MaxRest;  // minimum sensor value at rest
 	int throttle2MinRest;  // minimum sensor value at rest
 	int throttle2MaxRest;  // maximum sensor value at rest
+	int throttle1MinFluctuationPercent;
+	int throttle1MaxFluctuationPercent;
+	int throttle2MinFluctuationPercent;
+	int throttle2MaxFluctuationPercent;
 	int maxThrottleReadingDeviationPercent;
 	// stats/counters when sampling
 	static const int maxSamples = 300;

--- a/config.h
+++ b/config.h
@@ -80,7 +80,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * MISCELLANEOUS
  *
  */
-#define CFG_THROTTLE_TOLERANCE  30 //the max that things can go over or under the min/max without fault - 1/10% each #
+#define CFG_THROTTLE_TOLERANCE  150 //the max that things can go over or under the min/max without fault - 1/10% each #
 
 
 /*
@@ -99,7 +99,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define ThrottleMinRegenValue	0		//how many percent of full power to use at minimal regen
 #define ThrottleMaxRegenValue	0		//how many percent of full power to use at maximum regen
 #define ThrottleCreepValue		0		//how many percent of full power to use at creep
-#define ThrottleMaxErrValue		75		//tenths of percentage allowable deviation between pedals
+#define ThrottleMaxErrValue		150		//tenths of percentage allowable deviation between pedals
 #define Throttle1MinValue		180		//Value ADC reads when pedal is up
 #define Throttle1MaxValue		930		//Value ADC reads when pedal fully depressed
 #define Throttle2MinValue		360		//Value ADC reads when pedal is up


### PR DESCRIPTION
Made some changes to the throttle calibration to fix issues since
refactoring. Also added output of percentage of fluctuation of pedal
values at rest and full throttle during calibration.
Changed the pot throttle to use a percentage threshold for validation
and not raw values
Implemented support for two throttles with the second inverted
Increased the config thresholds for invalid values since I am getting
in excess of 10% fluctuation in values
